### PR TITLE
Rogers fetch

### DIFF
--- a/src/utils/fetchData/fetchData.js
+++ b/src/utils/fetchData/fetchData.js
@@ -1,0 +1,42 @@
+import url from './backend-url';
+
+const decodeJSONOrDie = (res) => res.json();
+
+/* If the API returns an error the decoded object will contain a .error and .code property. If we see these we turn them into a real error and throw it so the caller can catch it and take steps to notify the user. */
+const dieIfError = (res) => {
+	if (res.error) {
+		const err = new Error(res.error);
+		err.status = res.code;
+		err.details = res;
+		throw err;
+	}
+	return res;
+};
+
+/* Fetches routes from the API. The first two params are mandatory, the third is an optional object. This object is where 'body' for POST and PUT requests is specified. 'auth' ensures the request is sent with the Authorization header. It defaults to true as most routes require it.
+ */
+const fetchData = (method, endpoint, options = {}) => {
+	const { body, auth = true } = options;
+
+	const headers = { 'content-type': 'application/JSON' };
+
+	if (auth) {
+		const authObject = localStorage.getItem('auth');
+		const { token } = JSON.parse(authObject);
+		headers.authorization = `Bearer ${token}`;
+	}
+
+	const fetchObj = {
+		method,
+		mode: 'cors',
+		headers,
+	};
+
+	if (body) fetchObj.body = JSON.stringify(body);
+
+	return fetch(url + endpoint, fetchObj)
+		.then(decodeJSONOrDie)
+		.then(dieIfError);
+};
+
+export default fetchData;

--- a/src/utils/fetchData/fetchData.test.js
+++ b/src/utils/fetchData/fetchData.test.js
@@ -1,0 +1,126 @@
+import fetchData from './fetchData';
+
+const originalFetch = global.fetch;
+
+// Fetch POST route, no auth needed - happy path
+// Fetch POST route, no auth needed - happy path
+// Fetch POST route, no auth needed - happy path
+test('Fetch request to /login - happy path', () => {
+	const body = {
+		email: 'vatsal@iscool.com',
+		password: 'password',
+	};
+
+	// Mock the response to our fetch request
+	const fetchPayload = {
+		token: 'qwertyuiop',
+		expires: 1590216865, // need real time + offset
+		user_id: 1,
+		user_name: 'vatsal',
+	};
+	const mockFetchResponse = { json: () => fetchPayload };
+	global.fetch = (p1, p2) => {
+		// Check fetch called with right params
+		expect(p1).toBeDefined();
+		expect(p2).toBeDefined();
+		expect(p2.mode).toBe('cors');
+		expect(p2.headers).toBeDefined();
+		expect(p2.headers['content-type']).toBeDefined();
+		expect(p2.headers['content-type']).toBe('application/JSON');
+		return Promise.resolve(mockFetchResponse);
+	};
+
+	fetchData('POST', '/login', { body, auth: false }).then((response) => {
+		expect(response.token).toBeDefined();
+		expect(response.user_name).toBeDefined();
+		expect(response.user_id).toBeDefined();
+		expect(response.expires).toBeDefined();
+		expect(response.user_name).toBe('vatsal');
+		expect(typeof response.user_id).toBe(typeof 1);
+		expect(typeof response.expires).toBe(typeof 1);
+	});
+});
+
+// Fetch POST route, bad params, should get error
+// Fetch POST route, bad params, should get error
+// Fetch POST route, bad params, should get error
+test('Fetch request to /login - wrong password', () => {
+	const body = {
+		email: 'vatsal@iscool.com',
+		password: 'pissword',
+	};
+
+	// Mock the response to our fetch request
+	const fetchPayload = {
+		error: 'Generic Error',
+		code: 345,
+	};
+	const mockFetchResponse = { json: () => fetchPayload };
+	global.fetch = (p1, p2) => {
+		expect(p2).toBeDefined();
+		expect(p2.mode).toBe('cors');
+		expect(p2.headers).toBeDefined();
+		expect(p2.headers['content-type']).toBeDefined();
+		expect(p2.headers['content-type']).toBe('application/JSON');
+		return Promise.resolve(mockFetchResponse);
+	};
+
+	// Func should throw, this func should never run
+	const dontCall = jest.fn((r) => r);
+
+	fetchData('POST', '/login', { body, auth: false })
+		.then(dontCall)
+		.catch((err) => {
+			expect(err.message).toBeDefined();
+			expect(err.message).toBe('Generic Error');
+			expect(err.status).toBe(345);
+			expect(err.details).toBeDefined();
+		});
+	expect(dontCall).not.toHaveBeenCalled();
+});
+
+// Fetch DELETE route, auth required - happy path
+// Fetch DELETE route, auth required - happy path
+// Fetch DELETE route, auth required - happy path
+test('Fetch request to /delete - happy path', () => {
+	// Mock the response to our fetch request
+	const fetchPayload = { status: 'OK' };
+	const mockFetchResponse = { json: () => fetchPayload };
+	global.fetch = (p1, p2) => {
+		// global.fetch = () => jest.fn.mockImplementation(
+		expect(p2.headers).toBeDefined();
+		expect(p2.headers.authorization).toBeDefined();
+		expect(p2.headers.authorization).toBe('Bearer qwertyuiop');
+		return Promise.resolve(mockFetchResponse);
+	};
+
+	// Mock the response to our localstorage requests
+	Storage.prototype.getItem = () => {
+		return JSON.stringify({ token: 'qwertyuiop' });
+	};
+
+	fetchData('DELETE', '/delete/123').then((response) => {
+		expect(response.status).toBeDefined();
+		expect(response.status).toBe('OK');
+	});
+});
+
+// Do an actual fetch to the real /login route
+// Do an actual fetch to the real /login route
+// Do an actual fetch to the real /login route
+test.skip('Actual fetch request to live API /login', () => {
+	const body = {
+		email: 'admin@iscool.com',
+		password: 'password',
+	};
+	global.fetch = originalFetch;
+	fetchData('POST', '/login', { body, auth: false }).then((response) => {
+		expect(response.token).toBeDefined();
+		expect(response.user_name).toBeDefined();
+		expect(response.user_id).toBeDefined();
+		expect(response.expires).toBeDefined();
+		expect(response.user_name).toBe('vatsal');
+		expect(typeof response.user_id).toBe(typeof 1);
+		expect(typeof response.expires).toBe(typeof 1);
+	});
+});


### PR DESCRIPTION
I refactored the existing get-fetch and post-fetch functions into one that can use any verb e.g. GET, PUT, POST, DELETE etc. The api is slightly different though and I didn't want to refactor any code that used the original functions til this had had eyes on it. Consequently I haven't plumbed it into anything yet and I've not deleted the original files.

The api is: fetchData(verb, path, { options }).then( whatever )

The options object is optional, as are all it's properties.
The authorization header is sent by default but can be disabled in options
options = { body: {object of your choosing}, auth: false }

